### PR TITLE
Add support for RWops versions of functions

### DIFF
--- a/src/centurion/animation.hpp
+++ b/src/centurion/animation.hpp
@@ -44,6 +44,7 @@
 
 #include "common.hpp"
 #include "detail/stdlib.hpp"
+#include "filesystem.hpp"
 #include "math.hpp"
 #include "surface.hpp"
 
@@ -76,6 +77,17 @@ class animation final
   [[nodiscard]] static auto load(const std::string& file) -> animation
   {
     return load(file.c_str());
+  }
+
+  [[nodiscard]] static auto load(file& file) -> animation
+  {
+    assert(file.is_ok());
+    if (auto* ptr = IMG_LoadAnimation_RW(file.data(), 0)) {
+      return animation{ptr};
+    }
+    else {
+      throw img_error{};
+    }
   }
 
   [[nodiscard]] auto at(const usize index) -> surface_handle

--- a/src/centurion/animation.hpp
+++ b/src/centurion/animation.hpp
@@ -90,6 +90,17 @@ class animation final
     }
   }
 
+  [[nodiscard]] static auto load(file&& file) -> animation
+  {
+    assert(file.is_ok());
+    if (auto* ptr = IMG_LoadAnimation_RW(file.release(), 1)) {
+      return animation{ptr};
+    }
+    else {
+      throw img_error{};
+    }
+  }
+
   [[nodiscard]] auto at(const usize index) -> surface_handle
   {
     if (index < count()) {

--- a/src/centurion/audio.hpp
+++ b/src/centurion/audio.hpp
@@ -40,6 +40,7 @@
 #include "detail/owner_handle_api.hpp"
 #include "detail/stdlib.hpp"
 #include "features.hpp"
+#include "filesystem.hpp"
 #include "memory.hpp"
 
 #if CENTURION_HAS_FEATURE_FORMAT
@@ -167,6 +168,13 @@ class music final
   }
 
   explicit music(const std::string& file) : music{file.c_str()} {}
+
+  explicit music(file& file) : mMusic{Mix_LoadMUS_RW(file.data(), 0)}
+  {
+    if (!mMusic) {
+      throw mix_error{};
+    }
+  }
 
   auto play(const int iterations = 0) noexcept -> maybe<channel_index>
   {
@@ -452,6 +460,14 @@ class basic_sound_effect final
   template <typename TT = T, detail::enable_for_owner<TT> = 0>
   explicit basic_sound_effect(const std::string& file) : basic_sound_effect{file.c_str()}
   {}
+
+  template <typename TT = T, detail::enable_for_owner<TT> = 0>
+  explicit basic_sound_effect(file& file) : mChunk{Mix_LoadWAV_RW(file.data(), 0)}
+  {
+    if (!mChunk) {
+      throw mix_error{};
+    }
+  }
 
   template <typename TT = T, detail::enable_for_handle<TT> = 0>
   explicit basic_sound_effect(const sound_effect& owner) noexcept : mChunk{owner.get()}

--- a/src/centurion/audio.hpp
+++ b/src/centurion/audio.hpp
@@ -176,6 +176,13 @@ class music final
     }
   }
 
+  explicit music(file&& file) : mMusic{Mix_LoadMUS_RW(file.release(), 1)}
+  {
+    if (!mMusic) {
+      throw mix_error{};
+    }
+  }
+
   auto play(const int iterations = 0) noexcept -> maybe<channel_index>
   {
     const auto channel = Mix_PlayMusic(mMusic.get(), detail::max(iterations, forever));
@@ -463,6 +470,14 @@ class basic_sound_effect final
 
   template <typename TT = T, detail::enable_for_owner<TT> = 0>
   explicit basic_sound_effect(file& file) : mChunk{Mix_LoadWAV_RW(file.data(), 0)}
+  {
+    if (!mChunk) {
+      throw mix_error{};
+    }
+  }
+
+  template <typename TT = T, detail::enable_for_owner<TT> = 0>
+  explicit basic_sound_effect(file&& file) : mChunk{Mix_LoadWAV_RW(file.release(), 1)}
   {
     if (!mChunk) {
       throw mix_error{};

--- a/src/centurion/controller.hpp
+++ b/src/centurion/controller.hpp
@@ -940,6 +940,18 @@ inline auto load_controller_mappings(file& file) noexcept -> maybe<int>
   }
 }
 
+inline auto load_controller_mappings(file&& file) noexcept -> maybe<int>
+{
+  assert(file.is_ok());
+  const auto result = SDL_GameControllerAddMappingsFromRW(file.release(), 1);
+  if (result != -1) {
+    return result;
+  }
+  else {
+    return nothing;
+  }
+}
+
 template <typename T>
 [[nodiscard]] auto to_string(const basic_controller<T>& controller) -> std::string
 {

--- a/src/centurion/controller.hpp
+++ b/src/centurion/controller.hpp
@@ -41,6 +41,7 @@
 #include "detail/sdl_version_at_least.hpp"
 #include "detail/stdlib.hpp"
 #include "features.hpp"
+#include "filesystem.hpp"
 #include "input.hpp"
 #include "joystick.hpp"
 #include "sensor.hpp"
@@ -925,6 +926,18 @@ inline auto load_controller_mappings(const std::string& file) noexcept -> maybe<
 [[nodiscard]] inline auto controller_mapping_count() noexcept -> int
 {
   return SDL_GameControllerNumMappings();
+}
+
+inline auto load_controller_mappings(file& file) noexcept -> maybe<int>
+{
+  assert(file.is_ok());
+  const auto result = SDL_GameControllerAddMappingsFromRW(file.data(), 0);
+  if (result != -1) {
+    return result;
+  }
+  else {
+    return nothing;
+  }
 }
 
 template <typename T>

--- a/src/centurion/font.hpp
+++ b/src/centurion/font.hpp
@@ -231,6 +231,20 @@ class font final
     }
   }
 
+  font(file&& file, const int size) : mSize{size}
+  {
+    assert(file.is_ok());
+
+    if (mSize <= 0) {
+      throw exception{"Bad font size!"};
+    }
+
+    mFont.reset(TTF_OpenFontRW(file.release(), 1, mSize));
+    if (!mFont) {
+      throw ttf_error{};
+    }
+  }
+
 #if SDL_TTF_VERSION_ATLEAST(2, 0, 18)
 
   font(const char* file, const int size, const font_dpi& dpi) : mSize{size}
@@ -260,6 +274,20 @@ class font final
     }
 
     mFont.reset(TTF_OpenFontDPIRW(file.data(), 0, mSize, dpi.horizontal, dpi.vertical));
+    if (!mFont) {
+      throw ttf_error{};
+    }
+  }
+
+  font(file&& file, const int size, const font_dpi& dpi) : mSize{size}
+  {
+    assert(file.is_ok());
+
+    if (mSize <= 0) {
+      throw exception{"Bad font size!"};
+    }
+
+    mFont.reset(TTF_OpenFontDPIRW(file.release(), 1, mSize, dpi.horizontal, dpi.vertical));
     if (!mFont) {
       throw ttf_error{};
     }
@@ -838,6 +866,8 @@ class font_cache final
   font_cache(const std::string& file, const int size) : mFont{file, size} {}
 
   font_cache(file& file, const int size) : mFont{file, size} {}
+
+  font_cache(file&& file, const int size) : mFont{std::move(file), size} {}
 
   explicit font_cache(font&& font) noexcept : mFont{std::move(font)} {}
 

--- a/src/centurion/font.hpp
+++ b/src/centurion/font.hpp
@@ -46,6 +46,7 @@
 #include "common.hpp"
 #include "detail/stdlib.hpp"
 #include "features.hpp"
+#include "filesystem.hpp"
 #include "math.hpp"
 #include "memory.hpp"
 #include "render.hpp"
@@ -216,6 +217,20 @@ class font final
 
   font(const std::string& file, const int size) : font{file.c_str(), size} {}
 
+  font(file& file, const int size) : mSize{size}
+  {
+    assert(file.is_ok());
+
+    if (mSize <= 0) {
+      throw exception{"Bad font size!"};
+    }
+
+    mFont.reset(TTF_OpenFontRW(file.data(), 0, mSize));
+    if (!mFont) {
+      throw ttf_error{};
+    }
+  }
+
 #if SDL_TTF_VERSION_ATLEAST(2, 0, 18)
 
   font(const char* file, const int size, const font_dpi& dpi) : mSize{size}
@@ -235,6 +250,20 @@ class font final
   font(const std::string& file, const int size, const font_dpi& dpi)
       : font{file.c_str(), size, dpi}
   {}
+
+  font(file& file, const int size, const font_dpi& dpi) : mSize{size}
+  {
+    assert(file.is_ok());
+
+    if (mSize <= 0) {
+      throw exception{"Bad font size!"};
+    }
+
+    mFont.reset(TTF_OpenFontDPIRW(file.data(), 0, mSize, dpi.horizontal, dpi.vertical));
+    if (!mFont) {
+      throw ttf_error{};
+    }
+  }
 
 #endif  // SDL_TTF_VERSION_ATLEAST(2, 0, 18)
 
@@ -807,6 +836,8 @@ class font_cache final
   font_cache(const char* file, const int size) : mFont{file, size} {}
 
   font_cache(const std::string& file, const int size) : mFont{file, size} {}
+
+  font_cache(file& file, const int size) : mFont{file, size} {}
 
   explicit font_cache(font&& font) noexcept : mFont{std::move(font)} {}
 

--- a/src/centurion/render.hpp
+++ b/src/centurion/render.hpp
@@ -46,6 +46,7 @@
 #include "detail/owner_handle_api.hpp"
 #include "detail/stdlib.hpp"
 #include "features.hpp"
+#include "filesystem.hpp"
 #include "math.hpp"
 #include "surface.hpp"
 #include "texture.hpp"
@@ -165,10 +166,10 @@ class basic_renderer final
 
 #ifndef CENTURION_NO_SDL_IMAGE
 
-  [[nodiscard]] auto make_texture(const char* path) const -> texture
+  [[nodiscard]] auto make_texture(const char* file) const -> texture
   {
-    assert(path);
-    if (auto* ptr = IMG_LoadTexture(get(), path)) {
+    assert(file);
+    if (auto* ptr = IMG_LoadTexture(get(), file)) {
       return texture{ptr};
     }
     else {
@@ -176,9 +177,31 @@ class basic_renderer final
     }
   }
 
-  [[nodiscard]] auto make_texture(const std::string& path) const -> texture
+  [[nodiscard]] auto make_texture(const std::string& file) const -> texture
   {
-    return make_texture(path.c_str());
+    return make_texture(file.c_str());
+  }
+
+  [[nodiscard]] auto make_texture(file& file) const -> texture
+  {
+    assert(file.is_ok());
+    if (auto* ptr = IMG_LoadTexture_RW(get(), file.data(), 0)) {
+      return texture{ptr};
+    }
+    else {
+      throw img_error{};
+    }
+  }
+
+  [[nodiscard]] auto make_texture(file&& file) const -> texture
+  {
+    assert(file.is_ok());
+    if (auto* ptr = IMG_LoadTexture_RW(get(), file.release(), 1)) {
+      return texture{ptr};
+    }
+    else {
+      throw img_error{};
+    }
   }
 
 #endif  // CENTURION_NO_SDL_IMAGE


### PR DESCRIPTION
Introduces support for using RWops (or, more specifically, `cen::file` wrapper of this library) for file-related operations in SDL and its libraries. Main usecase is cooperation with physfsrwops wrapper from physfs project (`cen::file` is used to wrap RWops objects created by it).

All functions of RWops family have a parameter that allows to close file upon completion. I've decided not to set or expose it as `cen::file` takes care to close handle on destruction anyways.