### PR TITLE
Add file.release() and file.close() functions

### DIFF
--- a/src/centurion/filesystem.hpp
+++ b/src/centurion/filesystem.hpp
@@ -439,6 +439,15 @@ class file final
 
   [[nodiscard]] auto is_ok() const noexcept -> bool { return mContext != nullptr; }
 
+  /**
+    * Obtain ownership of the underlying SDL_RWops handle.
+    *
+    * This makes object unusable and caller must take care to close handle.
+    * Main use case of this function is when third-party library takes ownership
+    * of a file handle, i.e. promises to close it once done.
+    */
+  [[nodiscard]] auto release() noexcept -> SDL_RWops* { return mContext.release(); }
+
   /// Indicates whether the file handle is valid.
   explicit operator bool() const noexcept { return is_ok(); }
 

--- a/src/centurion/filesystem.hpp
+++ b/src/centurion/filesystem.hpp
@@ -445,12 +445,11 @@ class file final
     * This invalidates object and caller must take care to close handle.
     * Main use case of this function is when third-party library takes ownership
     * of a file handle, i.e. promises to close it once done.
+    *
+    * It is allowed to call this on objects which do not manage a handle, which
+    * will simply return `nullptr`.
     */
-  [[nodiscard]] auto release() noexcept -> SDL_RWops*
-  {
-    assert(mContext);
-    return mContext.release();
-  }
+  [[nodiscard]] auto release() noexcept -> SDL_RWops* { return mContext.release(); }
 
   /**
    * Close the file and invalidate object.

--- a/src/centurion/filesystem.hpp
+++ b/src/centurion/filesystem.hpp
@@ -442,11 +442,26 @@ class file final
   /**
     * Obtain ownership of the underlying SDL_RWops handle.
     *
-    * This makes object unusable and caller must take care to close handle.
+    * This invalidates object and caller must take care to close handle.
     * Main use case of this function is when third-party library takes ownership
     * of a file handle, i.e. promises to close it once done.
     */
-  [[nodiscard]] auto release() noexcept -> SDL_RWops* { return mContext.release(); }
+  [[nodiscard]] auto release() noexcept -> SDL_RWops*
+  {
+    assert(mContext);
+    return mContext.release();
+  }
+
+  /**
+   * Close the file and invalidate object.
+   *
+   * Unlike destructor, this allows you to check that flushing was successful.
+   */
+  auto close() noexcept -> result
+  {
+    assert(mContext);
+    return SDL_RWclose(release()) == 0;
+  }
 
   /// Indicates whether the file handle is valid.
   explicit operator bool() const noexcept { return is_ok(); }


### PR DESCRIPTION
I've looked into adding support for [SDL_sound](https://github.com/icculus/SDL_sound) and noticed that its creation function takes ownership of RWops passed to it - which is because it reads and decodes long after its creation function finished. To allow centurion to support this case of ownership transfer I've added a `steal` function to file class.