### PR TITLE
Store a copy of reason string in exceptions

### DIFF
--- a/src/centurion/common.hpp
+++ b/src/centurion/common.hpp
@@ -39,7 +39,9 @@
 #include <SDL_ttf.h>
 #endif  // CENTURION_NO_SDL_TTF
 
+#include <array>        // array
 #include <chrono>       // duration
+#include <cstring>      // strncpy
 #include <cstddef>      // size_t
 #include <exception>    // exception
 #include <memory>       // unique_ptr
@@ -168,12 +170,16 @@ class exception : public std::exception
  public:
   exception() noexcept = default;
 
-  explicit exception(const char* what) noexcept : mWhat{what ? what : "?"} {}
+  explicit exception(const char* what) noexcept
+  {
+    if (what)
+      std::strncpy(mWhat.data(), what, mWhat.size() - 1);
+  }
 
-  [[nodiscard]] auto what() const noexcept -> const char* override { return mWhat; }
+  [[nodiscard]] auto what() const noexcept -> const char* override { return mWhat.data(); }
 
  private:
-  const char* mWhat{"?"};
+  std::array<char, 128> mWhat{'?'};
 };
 
 class sdl_error final : public exception


### PR DESCRIPTION
Closes #129. This fixes a problem if exception is thrown across threads or one of destructors called during stack unwinding sets error.

I've used an array instead of `std::string` object to address concerns on OOM-situation discussed in linked issue. If implementation preallocates sufficient exception memory this will avoid extra allocation.  128 bytes is what SDL itself uses for error string storage.