### PR TITLE
Events: Expose WaitEvent and WaitEventTimeout

### DIFF
--- a/src/centurion/events/event_handler.hpp
+++ b/src/centurion/events/event_handler.hpp
@@ -69,6 +69,32 @@ class event_handler final {
     SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
   }
 
+  // Waits until an event is available
+  void wait()
+  {
+    SDL_Event event {};
+    if (SDL_WaitEvent(&event)) {
+      store(event);
+    }
+    else {
+      throw sdl_error {};
+    }
+  }
+
+  // Waits until an event is available or timeout
+  auto wait(int timeout) noexcept -> bool
+  {
+    SDL_Event event {};
+    if (SDL_WaitEventTimeout(&event, timeout)) {
+      store(event);
+      return true;
+    }
+    else {
+      reset_state();
+      return false;
+    }
+  }
+
   /// Polls the next available event, if there is one.
   auto poll() noexcept -> bool
   {


### PR DESCRIPTION
Does what it says on the tin, because sometimes you want a dumb app that doesn't eat 100% of CPU when it doesn't have anything to do.

The `SDL_WaitEventTimeout` can technically cause an error, but SDL doesn't provide or recommend any reliable way to differentiate that error from a regular timeout so :shrug:. Let's just pretend it can't.